### PR TITLE
Suggestions: Deck Region Icons

### DIFF
--- a/UI/src/components/deck/DeckRegions.vue
+++ b/UI/src/components/deck/DeckRegions.vue
@@ -121,7 +121,7 @@ export default {
     .btn:hover .icon-container .icon.faction, 
     .btn.active .icon-container .icon.faction {
         opacity: 1;
-        filter: brightness(0) invert(1) drop-shadow(1px 2px 1px rgba(0, 0, 0, 0.6));
+        filter: brightness(1.25) drop-shadow(1px 2px 1px rgba(0, 0, 0, 0.6));
     }
 
     

--- a/UI/src/components/deck/DeckRegions.vue
+++ b/UI/src/components/deck/DeckRegions.vue
@@ -97,7 +97,7 @@ export default {
                 }
             }
             
-            return factionIDs
+            return factionIDs.sort((a,b) => a-b)
         }
     },
     methods: {

--- a/UI/src/components/image/RegionIcon.vue
+++ b/UI/src/components/image/RegionIcon.vue
@@ -66,10 +66,7 @@ export default {
         /* width: 26px; */
         padding: 9px 9px;
         /* padding-left: 0px; */
-        filter: brightness(0) invert(1) drop-shadow(0.5px 1px 0.5px rgba(0, 0, 0, 0.1));
-        /* box-shadow: 2px 2px 3px -2px black; */
-        /* filter: drop-shadow(-2px 2px 1px rgba(43, 38, 27, 0.6)); */
-        /* filter: drop-shadow(-0.5px 1px 0.5px white); */
+        filter: drop-shadow(0.5px 1px 0.5px rgba(0, 0, 0, 0.1));
     }
 
     /* .icon.faction:hover {


### PR DESCRIPTION
Hey guys,
I decided to go ahead and implement a few minor suggestions for the deck components.

1. Colorize the icons for easier browsing - I was having a harder time differentiating between the region icons while browsing the meta environment, and I think having them colored would be a better user experience overall.
![image](https://user-images.githubusercontent.com/6902967/151688202-e1412c02-ca62-4efd-bb3a-f865a468fb07.png)

2. Sorted the icons by faction id - this makes it so the faction ids appear as they do in the client. Also makes it more consistent when seeing a list of decks.

Do let me know of any feedback. 
You can reach me on twitter @jzolago

I appreciate what you've done for the community, and hope you keep it up!
